### PR TITLE
Add Document decorator support; add access to underlying mongo_db.

### DIFF
--- a/flask_mongokit.py
+++ b/flask_mongokit.py
@@ -190,13 +190,6 @@ class MongoKit(object):
         ctx = _request_ctx_stack.top
         return hasattr(ctx, 'mongokit_db')
        
-    @property
-    def mongokit_db(self):
-        if self.connected:
-            return _request_ctx_stack.top.mongokit_db
-
-        return None
-
     def disconnect(self):
         """Close the connection to your MongoDB."""
         ctx = _request_ctx_stack.top

--- a/flaskext/mongokit.py
+++ b/flaskext/mongokit.py
@@ -127,12 +127,40 @@ class MongoKit(object):
         """Register one or more :class:`mongokit.Document` instances to the 
         connection.
         
+        Can be also used as a decorator on documents:
+
+        .. code-block:: python
+        
+            db = MongoKit(app)
+
+            @db.register
+            class Task(Document):
+                structure = {
+                   'title': unicode,
+                   'text': unicode,
+                   'creation': datetime,
+                }
+
         :param documents: A :class:`list` of :class:`mongokit.Document`.
         """
+
+        #enable decorator usage as in mongokit.Connection
+        decorator = None
+        if not isinstance(documents, (list, tuple, set, frozenset)):
+            # we assume that the user used this as a decorator
+            # using @register syntax or using db.register(SomeDoc)
+            # we stock the class object in order to return it later
+            decorator = documents
+            documents = [documents]
+
         for document in documents:
             if document not in self.registered_documents:
                 self.registered_documents.append(document)
-        return self.registered_documents
+
+        if decorator is None:
+            return self.registered_documents
+        else:
+            return decorator
     
     def connect(self):
         """Connect to the MongoDB server and register the documents from

--- a/flaskext/mongokit.py
+++ b/flaskext/mongokit.py
@@ -188,7 +188,14 @@ class MongoKit(object):
         """Connection status to your MongoDB."""
         ctx = _request_ctx_stack.top
         return hasattr(ctx, 'mongokit_db')
-        
+       
+    @property
+    def mongokit_db(self):
+        if self.connected:
+            return _request_ctx_stack.top.mongokit_db
+
+        return None
+
     def disconnect(self):
         """Close the connection to your MongoDB."""
         ctx = _request_ctx_stack.top

--- a/tests.py
+++ b/tests.py
@@ -50,6 +50,15 @@ class TestCase(unittest.TestCase):
         assert isinstance(self.db, MongoKit)
         assert self.db.name == self.app.config['MONGODB_DATABASE']
         assert isinstance(self.db.test, Collection)
+
+    def test_decorator_registration(self):
+        
+        @self.db.register
+        class DecoratorRegistered(Document):
+            pass
+
+        assert len(self.db.registered_documents) > 0
+        assert self.db.registered_documents[0] == DecoratorRegistered
     
     def test_property_connected(self):
         assert not self.db.connected


### PR DESCRIPTION
Sorry if this pull request has two changes, I was fooled by the repo reorganisation and did not know how to re-separate my changes.
- Added support for decorating documents, as can be done in mongokit. Usage:

``` python
@db.register
class MyDoc(Document)
    pass
```
- Added support for fetching the wrapped mongo_db object
